### PR TITLE
update types for by_route_type function

### DIFF
--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -93,8 +93,8 @@ defmodule MBTAV3API.Stops.Repo do
     end)
   end
 
-  @spec by_route_type(Route.route_type()) :: stops_response()
-  @spec by_route_type(Route.route_type(), Keyword.t()) :: stops_response()
+  @spec by_route_type(Route.type_int()) :: stops_response()
+  @spec by_route_type(Route.type_int(), Keyword.t()) :: stops_response()
   def by_route_type(route_type, opts \\ []) do
     {by_route_type_fn, opts} = Keyword.pop(opts, :by_route_type_fn, &Api.by_route_type/1)
 


### PR DESCRIPTION
[related to this ticket](https://app.asana.com/0/1204819229687089/1208899636045777/f)

Doing some refactoring in a different card, and realized that this function in our API library is expecting the wrong type. It was expecing atom names for route types (eg :bus) and it's actually getting integers. Updated it to reflect the actual usage.