### PR TITLE
add "all" and "get for Lines

### DIFF
--- a/lib/mbta_v3_api/application.ex
+++ b/lib/mbta_v3_api/application.ex
@@ -27,6 +27,7 @@ defmodule MBTAV3API.Application do
       MBTAV3API.Cache,
       MBTAV3API.Schedules.Repo,
       MBTAV3API.Facilities.Repo,
+      MBTAV3API.Lines.Repo,
       MBTAV3API.Stops.Repo,
       MBTAV3API.Routes.Supervisor,
       MBTAV3API.Services.Repo,

--- a/lib/mbta_v3_api/lines.ex
+++ b/lib/mbta_v3_api/lines.ex
@@ -1,0 +1,15 @@
+defmodule MBTAV3API.Lines do
+  @moduledoc """
+  Fetch Line data from the MBTA V3 API.
+  """
+
+  def all(params \\ []) do
+    {get_json_fn, params} = Keyword.pop(params, :get_json_fn, &MBTAV3API.get_json/2)
+    get_json_fn.("/lines/", params)
+  end
+
+  def get(id, params \\ []) do
+    {get_json_fn, params} = Keyword.pop(params, :get_json_fn, &MBTAV3API.get_json/2)
+    get_json_fn.("/lines/#{id}", params)
+  end
+end

--- a/lib/mbta_v3_api/lines/line.ex
+++ b/lib/mbta_v3_api/lines/line.ex
@@ -1,0 +1,23 @@
+defmodule MBTAV3API.Lines.Line do
+  @moduledoc """
+  A line.
+  """
+
+  @derive Jason.Encoder
+
+  defstruct [
+    :id,
+    :name,
+    :long_name,
+    :sort_order,
+    :route_ids
+  ]
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          long_name: String.t(),
+          name: String.t(),
+          sort_order: integer(),
+          route_ids: [String.t()]
+        }
+end

--- a/lib/mbta_v3_api/lines/parser.ex
+++ b/lib/mbta_v3_api/lines/parser.ex
@@ -1,0 +1,27 @@
+defmodule MBTAV3API.Lines.Parser do
+  @moduledoc "Functions for parsing generic JSON:API structs into Lines structs."
+
+  alias JsonApi.Item
+  alias MBTAV3API.Lines.Line
+
+  @spec parse_line(Item.t()) :: Line.t()
+  def parse_line(%Item{id: id, attributes: attributes, relationships: relationships}) do
+    %Line{
+      id: id,
+      name: name(attributes),
+      long_name: attributes["long_name"],
+      sort_order: attributes["sort_order"],
+      route_ids: parse_route_ids(relationships)
+    }
+  end
+
+  defp parse_route_ids(%{"routes" => [_ | _] = routes}) do
+    Enum.map(routes, & &1.id)
+  end
+
+  defp parse_route_ids(_), do: nil
+
+  @spec name(map) :: String.t()
+  def name(%{"long_name" => long_name, "short_name" => ""}), do: long_name
+  def name(%{"short_name" => short_name}), do: short_name
+end

--- a/lib/mbta_v3_api/lines/repo.ex
+++ b/lib/mbta_v3_api/lines/repo.ex
@@ -1,0 +1,58 @@
+defmodule MBTAV3API.Lines.Repo do
+  @moduledoc "Repo for fetching Line resources and their associated data from the MBTA V3 API."
+
+  require Logger
+  use RepoCache, ttl: :timer.hours(1)
+  alias JsonApi
+  alias MBTAV3API.Lines
+  alias MBTAV3API.Lines.Parser
+
+  @default_opts [include: "routes"]
+
+  def all(opts \\ []) do
+    opts = @default_opts ++ opts
+
+    case cache(opts, fn _ ->
+           result = handle_response(Lines.all(@default_opts))
+
+           for {:ok, lines} <- [result],
+               line <- lines do
+             ConCache.put(__MODULE__, {:get, line.id}, {:ok, line})
+           end
+
+           result
+         end) do
+      {:ok, lines} -> lines
+      {:error, _} -> []
+    end
+  end
+
+  def get(id, opts \\ []) when is_binary(id) do
+    opts = @default_opts ++ opts
+
+    case cache({id, opts}, fn {id, opts} ->
+           with %{data: [line]} <- Lines.get(id, opts) do
+             {:ok, line}
+           end
+         end) do
+      {:ok, line} -> Parser.parse_line(line)
+      {:error, _} -> nil
+    end
+  end
+
+  @doc """
+  Parses json into a list of lines, or an error if it happened.
+  """
+  @spec handle_response(JsonApi.t() | {:error, any}) :: {:ok, [Line.t()]} | {:error, any}
+  def handle_response({:error, reason}) do
+    {:error, reason}
+  end
+
+  def handle_response(%{data: data}) do
+    {:ok,
+     data
+     |> Enum.map(&Parser.parse_line/1)
+     |> Enum.uniq()
+     |> Enum.sort_by(& &1.sort_order)}
+  end
+end

--- a/lib/mbta_v3_api/routes/repo.ex
+++ b/lib/mbta_v3_api/routes/repo.ex
@@ -28,8 +28,8 @@ defmodule MBTAV3API.Routes.Repo do
   }
 
   @impl RepoApi
-  def all do
-    case cache(@default_opts, fn _ ->
+  def all(opts \\ []) do
+    case cache(@default_opts ++ opts, fn _ ->
            result = handle_response(Routes.all(@default_opts))
 
            for {:ok, routes} <- [result],
@@ -47,7 +47,9 @@ defmodule MBTAV3API.Routes.Repo do
   # Used to spoof any Massport route as the data doesn't exist in the API
   # But is in the GTFS data
   @impl RepoApi
-  def get("Massport-" <> id) do
+  def get(id, opts \\ [])
+
+  def get("Massport-" <> id, _opts) do
     %Route{
       description: "Massport Generated Route",
       id: "Massport-" <> id,
@@ -59,8 +61,8 @@ defmodule MBTAV3API.Routes.Repo do
     }
   end
 
-  def get(id) when is_binary(id) do
-    opts = @default_opts
+  def get(id, opts) when is_binary(id) do
+    opts = @default_opts ++ opts
 
     case cache({id, opts}, fn {id, opts} ->
            with %{data: [route]} <- Routes.get(id, opts) do

--- a/test/mbta_v3_api/lines/repo_test.exs
+++ b/test/mbta_v3_api/lines/repo_test.exs
@@ -1,0 +1,48 @@
+defmodule MBTAV3API.Lines.RepoTest do
+  use ExUnit.Case, async: false
+
+  import MBTAV3API.Support.Factory
+  import Mock
+
+  alias MBTAV3API.Lines
+  alias MBTAV3API.Lines.{Repo, Line}
+
+  @item build(:line_data)
+
+  describe "all/0" do
+    test "returns a list of Lines" do
+      with_mock(Lines, all: fn _opts -> %JsonApi{data: [@item]} end) do
+        assert [%Line{} | _] = Repo.all()
+      end
+    end
+  end
+
+  test "parses the data into Line structs" do
+    with_mock(Lines, all: fn _opts -> %JsonApi{data: [@item]} end) do
+      assert Repo.all() |> List.first() == %Line{
+               id: "line-89",
+               long_name: "Clarendon Hill or Davis - Sullivan",
+               name: "89",
+               sort_order: 50890,
+               route_ids: ["89", "8993"]
+             }
+    end
+  end
+
+  describe "get/1" do
+    test "returns a single line" do
+      with_mock(Lines, get: fn "89", _opts -> %JsonApi{data: [@item]} end) do
+        assert %Line{
+                 id: "line-89",
+                 name: "89"
+               } = Repo.get("89")
+      end
+    end
+
+    test "returns nil for an unknown line" do
+      with_mock(Lines, get: fn _id, _opts -> {:error, "not found"} end) do
+        refute Repo.get("_unknown_line")
+      end
+    end
+  end
+end

--- a/test/mbta_v3_api/lines_test.exs
+++ b/test/mbta_v3_api/lines_test.exs
@@ -1,0 +1,29 @@
+defmodule MBTAV3API.LinesTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias JsonApi.Item
+  alias MBTAV3API.Lines
+
+  @opts ["page[limit]": 1]
+
+  describe "all/1" do
+    test "gets all lines" do
+      response = %JsonApi{data: [%Item{}]}
+
+      opts = Keyword.put(@opts, :get_json_fn, fn "/lines/", @opts -> response end)
+
+      assert Lines.all(opts) == response
+    end
+  end
+
+  describe "get/1" do
+    test "gets the line by ID" do
+      response = %JsonApi{data: [%Item{id: "line-89"}]}
+
+      opts = Keyword.put(@opts, :get_json_fn, fn "/lines/89", @opts -> response end)
+
+      assert Lines.get("89", opts) == response
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -639,6 +639,30 @@ defmodule MBTAV3API.Support.Factory do
     }
   end
 
+  def line_data_factory do
+    %Item{
+      id: "line-89",
+      attributes: %{
+        "long_name" => "Clarendon Hill or Davis - Sullivan",
+        "short_name" => "89",
+        "sort_order" => 50890
+      },
+      relationships: %{
+        "routes" => [
+          %Item{
+            id: "89",
+            type: "route"
+          },
+          %Item{
+            id: "8993",
+            type: "route"
+          }
+        ]
+      },
+      type: "line"
+    }
+  end
+
   def raw_route_patterns_with_stops_factory do
     %JsonApi{
       links: %{},


### PR DESCRIPTION
[Ticket](https://app.asana.com/0/1204819229687089/1208917894002302/f)

I need to be able to get lines to get combo route IDs. While it's possible to get this information by including a `include line.routes` parameter to a get routes call, in practice the library didn't handle the returned JSON too well. I figured just adding the ability to get the lines directly was way faster and less risky.