### PR TITLE
Reduce number of api calls for stops

### DIFF
--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -103,6 +103,7 @@ defmodule MBTAV3API.Stops.Repo do
       fn stop ->
         stop
         |> by_route_type_fn.()
+        #removed "get parent call" to reduce number of API calls when getting stops
         |> Enum.uniq_by(& &1.id)
       end
     )

--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -103,7 +103,7 @@ defmodule MBTAV3API.Stops.Repo do
       fn stop ->
         stop
         |> by_route_type_fn.()
-        #removed "get parent call" to reduce number of API calls when getting stops
+        #removed "get_parent call" to reduce number of API calls when getting stops
         |> Enum.uniq_by(& &1.id)
       end
     )

--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -103,7 +103,6 @@ defmodule MBTAV3API.Stops.Repo do
       fn stop ->
         stop
         |> by_route_type_fn.()
-        |> Enum.map(&get_parent/1)
         |> Enum.uniq_by(& &1.id)
       end
     )


### PR DESCRIPTION
[ticket](https://app.asana.com/0/1204819229687089/1208308815807748)

This is only tangentially related to the ticket, but we were making extra API calls when we get stops, that aren't necessary. At times were were making so many calls that the cache threw errors. If we need this later we can put it back in on a conditional basis, but for right now, it's just unneeded.