### PR TITLE
Update get stops by route function

### DIFF
--- a/lib/mbta_v3_api/stops/api.ex
+++ b/lib/mbta_v3_api/stops/api.ex
@@ -60,6 +60,7 @@ defmodule MBTAV3API.Stops.Api do
     stops_all_fn = Keyword.get(opts, :stops_all_fn, &Stops.all/1)
 
     @default_params
+    |> Keyword.merge(opts)
     |> stops_all_fn.()
     |> parse_v3_multiple()
   end

--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -96,16 +96,19 @@ defmodule MBTAV3API.Stops.Repo do
   @spec by_route_type(Route.type_int()) :: stops_response()
   @spec by_route_type(Route.type_int(), Keyword.t()) :: stops_response()
   def by_route_type(route_type, opts \\ []) do
-    # gets stops that belong to the route, then gets parent ids of stops.
-    # makes a call to get all the parent stops using those ids, returns result
+    # gets stops that have the given route type. if stops have parent ids, it gathers
+    # them and makes a separate call to get the parents, otherwise just uses the stop
     {by_route_type_fn, opts} = Keyword.pop(opts, :by_route_type_fn, &Api.by_route_type/1)
     {all_stops_fn, opts} = Keyword.pop(opts, :all_stops_fn, &Api.all/1)
 
     cache(
       {route_type, opts},
       fn {route_type, opts} ->
+        #get all stops of route type
         stops = by_route_type_fn.({route_type, opts})
-
+        #get stops with no parents
+        stops_without_parents = Enum.reject(stops, &has_parent?/1)
+        #get ids of stops with parents
         parent_ids =
           stops
           |> Enum.filter(&has_parent?/1)
@@ -113,9 +116,12 @@ defmodule MBTAV3API.Stops.Repo do
           |> Enum.uniq()
           |> Enum.join(",")
 
-        all_stops_fn.(Keyword.put(opts, :filter, parent_ids))
+        #get parent stops from above ids
+        parent_stops = all_stops_fn.(Keyword.put(opts, :"filter[id]", parent_ids))
         |> Enum.reject(&has_parent?/1)
         |> Enum.uniq_by(& &1.id)
+
+        stops_without_parents ++ parent_stops
       end
     )
   end

--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -113,7 +113,7 @@ defmodule MBTAV3API.Stops.Repo do
           |> Enum.uniq()
           |> Enum.join(",")
 
-        all_stops_fn.(filter: parent_ids)
+        all_stops_fn.(Keyword.put(opts, :filter, parent_ids))
         |> Enum.reject(&has_parent?/1)
         |> Enum.uniq_by(& &1.id)
       end

--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -96,6 +96,34 @@ defmodule MBTAV3API.Stops.Repo do
   @spec by_route_type(Route.type_int()) :: stops_response()
   @spec by_route_type(Route.type_int(), Keyword.t()) :: stops_response()
   def by_route_type(route_type, opts \\ []) do
+    # gets stops that belong to the route, then gets parent ids of stops.
+    # makes a call to get all the parent stops using those ids, returns result
+    {by_route_type_fn, opts} = Keyword.pop(opts, :by_route_type_fn, &Api.by_route_type/1)
+    {all_stops_fn, opts} = Keyword.pop(opts, :all_stops_fn, &Api.all/1)
+
+    cache(
+      {route_type, opts},
+      fn {route_type, opts} ->
+        stops = by_route_type_fn.({route_type, opts})
+
+        parent_ids =
+          stops
+          |> Enum.filter(&has_parent?/1)
+          |> Enum.map(& &1.parent_id)
+          |> Enum.uniq()
+          |> Enum.join(",")
+
+        all_stops_fn.(filter: parent_ids)
+        |> Enum.reject(&has_parent?/1)
+        |> Enum.uniq_by(& &1.id)
+      end
+    )
+  end
+
+  @spec child_stops_by_route_type(Route.type_int()) :: stops_response()
+  @spec child_stops_by_route_type(Route.type_int(), Keyword.t()) :: stops_response()
+  def child_stops_by_route_type(route_type, opts \\ []) do
+    # like `by_route_type` but only returns child stops instead of parent stops
     {by_route_type_fn, opts} = Keyword.pop(opts, :by_route_type_fn, &Api.by_route_type/1)
 
     cache(
@@ -103,7 +131,6 @@ defmodule MBTAV3API.Stops.Repo do
       fn stop ->
         stop
         |> by_route_type_fn.()
-        #removed "get_parent call" to reduce number of API calls when getting stops
         |> Enum.uniq_by(& &1.id)
       end
     )

--- a/test/mbta_v3_api/stops/repo_test.exs
+++ b/test/mbta_v3_api/stops/repo_test.exs
@@ -133,16 +133,43 @@ defmodule MBTAV3API.Stops.RepoTest do
   end
 
   describe "by_route_type/2" do
-    test "returns stops filtered by route type" do
+    test "returns parent stops filtered by route type" do
       route_type = 2
       stop_id = "stop-id"
       stop = %Stop{id: stop_id, parent_id: nil}
+      child_stop_1_id = "child-id-1"
+      child_stop_1 = %Stop{id: child_stop_1_id, parent_id: stop_id}
+      child_stop_2_id = "child-id-2"
+      child_stop_2 = %Stop{id: child_stop_2_id, parent_id: stop_id}
 
-      opts = [by_route_type_fn: fn {^route_type, []} -> [stop, stop] end]
+      opts = [
+        by_route_type_fn: fn {^route_type, []} -> [child_stop_1, child_stop_2] end,
+        all_stops_fn: fn [filter: "stop-id"] -> [stop] end
+      ]
 
       response = Repo.by_route_type(route_type, opts)
 
       assert Enum.find(response, &(&1.id == stop_id))
+
+      # doesn't duplicate stops
+      assert Enum.uniq(response) == response
+    end
+  end
+
+  describe "child_stops_by_route_type/2" do
+    test "returns stops filtered by route type" do
+      route_type = 2
+      stop_id = "stop-id"
+      child_stop_1_id = "child-id-1"
+      child_stop_1 = %Stop{id: child_stop_1_id, parent_id: stop_id}
+      child_stop_2_id = "child-id-2"
+      child_stop_2 = %Stop{id: child_stop_2_id, parent_id: stop_id}
+
+      opts = [by_route_type_fn: fn {^route_type, []} -> [child_stop_1, child_stop_2] end]
+
+      response = Repo.child_stops_by_route_type(route_type, opts)
+
+      assert Enum.map(response, & &1.id) == [child_stop_1_id, child_stop_2_id]
 
       # doesn't duplicate stops
       assert Enum.uniq(response) == response

--- a/test/mbta_v3_api/stops/repo_test.exs
+++ b/test/mbta_v3_api/stops/repo_test.exs
@@ -144,7 +144,7 @@ defmodule MBTAV3API.Stops.RepoTest do
 
       opts = [
         by_route_type_fn: fn {^route_type, []} -> [child_stop_1, child_stop_2] end,
-        all_stops_fn: fn [filter: "stop-id"] -> [stop] end
+        all_stops_fn: fn ["filter[id]": "stop-id"] -> [stop] end
       ]
 
       response = Repo.by_route_type(route_type, opts)


### PR DESCRIPTION
[ticket](https://app.asana.com/0/1204819229687089/1209716286241150/f)

This (actually!) reduces the number of API calls made by the stops `by_route_type` function, by combining many calls into one call with a filter. I also added a `child_stops_by_route_type` function that gives back the child stops instead of the parent stops, since we know we're going to need it and it was very quick to add while I had the context.

Also updates test to demonstrate the difference.