### PR TITLE
Add some functions and pass opts into others

### DIFF
--- a/lib/mbta_v3_api/facilities/repo.ex
+++ b/lib/mbta_v3_api/facilities/repo.ex
@@ -7,6 +7,7 @@ defmodule MBTAV3API.Facilities.Repo do
   alias MBTAV3API.Facilities
   alias MBTAV3API.Facilities.Facility
 
+  @spec all(keyword(), keyword()) :: [Facility.t()]
   def all(params \\ [], opts \\ []) do
     case cache({params, opts}, fn {params, opts} ->
            with %{data: facilities} <- MBTAV3API.Facilities.all(params, opts) do
@@ -14,7 +15,7 @@ defmodule MBTAV3API.Facilities.Repo do
            end
          end) do
       {:ok, facilities} -> facilities |> Enum.map(&Facility.parse/1)
-      {:error, _} -> nil
+      {:error, _} -> []
     end
   end
 

--- a/lib/mbta_v3_api/facilities/repo.ex
+++ b/lib/mbta_v3_api/facilities/repo.ex
@@ -7,6 +7,17 @@ defmodule MBTAV3API.Facilities.Repo do
   alias MBTAV3API.Facilities
   alias MBTAV3API.Facilities.Facility
 
+  def all(params \\ [], opts \\ []) do
+    case cache({params, opts}, fn {params, opts} ->
+           with %{data: facilities} <- MBTAV3API.Facilities.all(params, opts) do
+             {:ok, facilities}
+           end
+         end) do
+      {:ok, facilities} -> facilities |> Enum.map(&Facility.parse/1)
+      {:error, _} -> nil
+    end
+  end
+
   def get(id, opts \\ []) when is_binary(id) do
     case cache({id, opts}, fn {id, opts} ->
            with %{data: [facility]} <- Facilities.get(id, opts) do

--- a/lib/mbta_v3_api/routes.ex
+++ b/lib/mbta_v3_api/routes.ex
@@ -8,9 +8,9 @@ defmodule MBTAV3API.Routes do
   @type api_response_t() :: JsonApi.t() | {:error, any}
 
   @spec all(keyword()) :: api_response_t()
-  def all(opts \\ []) do
-    {get_json_fn, opts} = Keyword.pop(opts, :get_json_fn, &MBTAV3API.get_json/2)
-    get_json_fn.("/routes/", opts)
+  def all(params \\ [], opts \\ []) do
+    {get_json_fn, opts} = Keyword.pop(opts, :get_json_fn, &MBTAV3API.get_json/3)
+    get_json_fn.("/routes/", params, opts)
   end
 
   @spec get(Route.id_t(), keyword()) :: api_response_t()

--- a/lib/mbta_v3_api/routes/repo.ex
+++ b/lib/mbta_v3_api/routes/repo.ex
@@ -28,6 +28,7 @@ defmodule MBTAV3API.Routes.Repo do
   }
 
   @impl RepoApi
+  @spec all(keyword(), keyword()) :: [Route.t()]
   def all(params \\ [], opts \\ []) do
     combined_params = @default_params ++ params
 

--- a/lib/mbta_v3_api/routes/repo.ex
+++ b/lib/mbta_v3_api/routes/repo.ex
@@ -13,7 +13,7 @@ defmodule MBTAV3API.Routes.Repo do
   alias MBTAV3API.Routes.{RepoApi, Route, Shape}
   alias MBTAV3API.Shapes
 
-  @default_opts [include: "route_patterns"]
+  @default_params [include: "route_patterns"]
 
   @green_line_virtual_route %Route{
     id: "Green",
@@ -28,11 +28,11 @@ defmodule MBTAV3API.Routes.Repo do
   }
 
   @impl RepoApi
-  def all(opts \\ []) do
-    combined_opts = @default_opts ++ opts
+  def all(params \\ [], opts \\ []) do
+    combined_params = @default_params ++ params
 
-    case cache(combined_opts, fn _ ->
-           result = handle_response(Routes.all(combined_opts))
+    case cache(combined_params, fn _ ->
+           result = handle_response(Routes.all(combined_params, opts))
 
            for {:ok, routes} <- [result],
                route <- routes do
@@ -64,7 +64,7 @@ defmodule MBTAV3API.Routes.Repo do
   end
 
   def get(id, opts) when is_binary(id) do
-    opts = @default_opts ++ opts
+    opts = @default_params ++ opts
 
     case cache({id, opts}, fn {id, opts} ->
            with %{data: [route]} <- Routes.get(id, opts) do
@@ -149,7 +149,7 @@ defmodule MBTAV3API.Routes.Repo do
 
   @impl RepoApi
   def by_stop(stop_id, opts \\ []) do
-    opts = Keyword.merge(@default_opts, opts)
+    opts = Keyword.merge(@default_params, opts)
 
     case cache({stop_id, opts}, fn {stop_id, opts} ->
            stop_id |> Routes.by_stop(opts) |> handle_response
@@ -161,7 +161,7 @@ defmodule MBTAV3API.Routes.Repo do
 
   @impl RepoApi
   def by_stop_and_direction(stop_id, direction_id, opts \\ []) do
-    opts = Keyword.merge(@default_opts, opts)
+    opts = Keyword.merge(@default_params, opts)
 
     case cache({stop_id, direction_id, opts}, fn {stop_id, direction_id, opts} ->
            stop_id

--- a/lib/mbta_v3_api/routes/repo.ex
+++ b/lib/mbta_v3_api/routes/repo.ex
@@ -31,7 +31,7 @@ defmodule MBTAV3API.Routes.Repo do
   def all(params \\ [], opts \\ []) do
     combined_params = @default_params ++ params
 
-    case cache(combined_params, fn _ ->
+    case cache({combined_params, opts}, fn {combined_params, opts} ->
            result = handle_response(Routes.all(combined_params, opts))
 
            for {:ok, routes} <- [result],

--- a/lib/mbta_v3_api/schedules/parser.ex
+++ b/lib/mbta_v3_api/schedules/parser.ex
@@ -55,6 +55,25 @@ defmodule MBTAV3API.Schedules.Parser do
   end
 
   def trip(%Item{
+        id: id,
+        attributes:
+          %{"name" => name, "headsign" => headsign, "direction_id" => direction_id} =
+            attributes,
+        relationships: relationships
+      }) do
+    %Trip{
+      id: id,
+      headsign: headsign,
+      name: name,
+      direction_id: direction_id,
+      bikes_allowed?: bikes_allowed?(attributes),
+      route_pattern_id: route_pattern_id(relationships),
+      shape_id: shape_id(relationships),
+      occupancy: occupancy(relationships)
+    }
+  end
+
+  def trip(%Item{
         relationships: %{
           "trip" => [
             %Item{

--- a/lib/mbta_v3_api/schedules/repo.ex
+++ b/lib/mbta_v3_api/schedules/repo.ex
@@ -78,9 +78,9 @@ defmodule MBTAV3API.Schedules.Repo do
     |> load_from_other_repos()
   end
 
-  @spec trips_by_ids(keyword(), keyword()) :: [Facility.t()]
+  @spec trips_by_ids(keyword(), keyword()) :: [Trip.t()]
   def trips_by_ids(trip_ids, params \\ [], opts \\ []) do
-    case cache({trip_ids, params, opts}, fn {params, opts} ->
+    case cache({trip_ids, params, opts}, fn {trip_ids, params, opts} ->
            with %{data: trips} <- MBTAV3API.Trips.by_ids(trip_ids, params, opts) do
              {:ok, trips}
            end

--- a/lib/mbta_v3_api/schedules/repo.ex
+++ b/lib/mbta_v3_api/schedules/repo.ex
@@ -78,6 +78,18 @@ defmodule MBTAV3API.Schedules.Repo do
     |> load_from_other_repos()
   end
 
+  @spec trips_by_ids(keyword(), keyword()) :: [Facility.t()]
+  def trips_by_ids(trip_ids, params \\ [], opts \\ []) do
+    case cache({trip_ids, params, opts}, fn {params, opts} ->
+           with %{data: trips} <- MBTAV3API.Trips.by_ids(trip_ids, params, opts) do
+             {:ok, trips}
+           end
+         end) do
+      {:ok, trips} -> trips |> Enum.map(&Parser.trip/1)
+      {:error, _} -> []
+    end
+  end
+
   @spec trip(String.t()) :: Trip.t() | nil
   @spec trip(String.t(), any()) :: Trip.t() | nil
   def trip(trip_id, trip_by_id_fn \\ &Trips.by_id/2)

--- a/lib/mbta_v3_api/stops.ex
+++ b/lib/mbta_v3_api/stops.ex
@@ -5,10 +5,10 @@ defmodule MBTAV3API.Stops do
 
   alias MBTAV3API.Stops.Stop
 
-  @spec all(keyword()) :: JsonApi.t() | {:error, any}
-  def all(opts \\ []) do
-    {get_json_fn, opts} = Keyword.pop(opts, :get_json_fn, &MBTAV3API.get_json/2)
-    get_json_fn.("/stops/", opts)
+  @spec all(keyword(), keyword()) :: JsonApi.t() | {:error, any}
+  def all(params \\ [], opts \\ []) do
+    {get_json_fn, opts} = Keyword.pop(opts, :get_json_fn, &MBTAV3API.get_json/3)
+    get_json_fn.("/stops/", params, opts)
   end
 
   @spec by_gtfs_id(Stop.id_t(), keyword(), keyword()) :: JsonApi.t() | {:error, any}

--- a/lib/mbta_v3_api/stops/api.ex
+++ b/lib/mbta_v3_api/stops/api.ex
@@ -56,12 +56,13 @@ defmodule MBTAV3API.Stops.Api do
     |> parse_v3_response()
   end
 
-  def all(opts \\ []) do
-    stops_all_fn = Keyword.get(opts, :stops_all_fn, &Stops.all/1)
+  @spec all(Keyword.t(), Keyword.t()) :: [Stop.t()]
+  def all(params \\ [], opts \\ []) do
+    stops_all_fn = Keyword.get(opts, :stops_all_fn, &Stops.all/2)
 
     @default_params
-    |> Keyword.merge(opts)
-    |> stops_all_fn.()
+    |> Keyword.merge(params)
+    |> stops_all_fn.(opts)
     |> parse_v3_multiple()
   end
 

--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -21,22 +21,19 @@ defmodule MBTAV3API.Stops.Repo do
   @type stops_response :: [Stop.t()] | {:error, any}
   @type stop_by_route :: (Route.id_t(), 0 | 1, Keyword.t() -> stops_response)
 
-  # def all(params \\ [], opts \\ []) do
+  @spec all(keyword(), keyword()) :: [Stop.t()]
+  def all(params \\ [], opts \\ []) do
+    cache({params, opts}, fn {params, opts} ->
+      result = Api.all(params, opts)
 
-  #   case cache(params, fn _ ->
-  #          result = Stops.all(params, opts)
+      for stops <- [result],
+          stop <- stops do
+        ConCache.put(__MODULE__, {:get, stop.id}, {:ok, stop})
+      end
 
-  #          for {:ok, stops} <- [result],
-  #              stop <- stops do
-  #            ConCache.put(__MODULE__, {:get, stop.id}, {:ok, stop})
-  #          end
-
-  #          result
-  #        end) do
-  #     {:ok, stops} -> stops
-  #     {:error, _} -> []
-  #   end
-  # end
+      result
+    end)
+  end
 
   @spec get(Stop.id_t()) :: Stop.t() | nil
   @spec get(Stop.id_t(), keyword()) :: Stop.t() | nil

--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -25,9 +25,7 @@ defmodule MBTAV3API.Stops.Repo do
   def all(params \\ [], opts \\ []) do
     cache({params, opts}, fn {params, opts} ->
       result = Api.all(params, opts)
-
-      for stops <- [result],
-          stop <- stops do
+      for stops <- [result], stop <- stops do
         ConCache.put(__MODULE__, {:get, stop.id}, {:ok, stop})
       end
 

--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -21,6 +21,23 @@ defmodule MBTAV3API.Stops.Repo do
   @type stops_response :: [Stop.t()] | {:error, any}
   @type stop_by_route :: (Route.id_t(), 0 | 1, Keyword.t() -> stops_response)
 
+  # def all(params \\ [], opts \\ []) do
+
+  #   case cache(params, fn _ ->
+  #          result = Stops.all(params, opts)
+
+  #          for {:ok, stops} <- [result],
+  #              stop <- stops do
+  #            ConCache.put(__MODULE__, {:get, stop.id}, {:ok, stop})
+  #          end
+
+  #          result
+  #        end) do
+  #     {:ok, stops} -> stops
+  #     {:error, _} -> []
+  #   end
+  # end
+
   @spec get(Stop.id_t()) :: Stop.t() | nil
   @spec get(Stop.id_t(), keyword()) :: Stop.t() | nil
   def get(id, opts \\ []) when is_binary(id) do
@@ -95,17 +112,17 @@ defmodule MBTAV3API.Stops.Repo do
 
   @spec by_route_type(Route.type_int()) :: stops_response()
   @spec by_route_type(Route.type_int(), Keyword.t()) :: stops_response()
-  def by_route_type(route_type, opts \\ []) do
+  def by_route_type(route_type, params \\ []) do
     # gets stops that have the given route type. if stops have parent ids, it gathers
     # them and makes a separate call to get the parents, otherwise just uses the stop
-    {by_route_type_fn, opts} = Keyword.pop(opts, :by_route_type_fn, &Api.by_route_type/1)
-    {all_stops_fn, opts} = Keyword.pop(opts, :all_stops_fn, &Api.all/1)
+    {by_route_type_fn, params} = Keyword.pop(params, :by_route_type_fn, &Api.by_route_type/1)
+    {all_stops_fn, params} = Keyword.pop(params, :all_stops_fn, &Api.all/2)
 
     cache(
-      {route_type, opts},
-      fn {route_type, opts} ->
+      {route_type, params},
+      fn {route_type, params} ->
         # get all stops of route type
-        stops = by_route_type_fn.({route_type, opts})
+        stops = by_route_type_fn.({route_type, params})
         # get stops with no parents
         stops_without_parents = Enum.reject(stops, &has_parent?/1)
         # get ids of stops with parents
@@ -118,7 +135,7 @@ defmodule MBTAV3API.Stops.Repo do
 
         # get parent stops from above ids
         parent_stops =
-          all_stops_fn.(Keyword.put(opts, :"filter[id]", parent_ids))
+          all_stops_fn.(Keyword.put(params, :"filter[id]", parent_ids), [])
           |> Enum.reject(&has_parent?/1)
           |> Enum.uniq_by(& &1.id)
 

--- a/lib/mbta_v3_api/trips.ex
+++ b/lib/mbta_v3_api/trips.ex
@@ -3,6 +3,7 @@ defmodule MBTAV3API.Trips do
   Responsible for fetching Trip data from the MBTA V3 API.
   """
 
+  @spec by_ids(list() | binary(), keyword(), keyword()) :: JsonApi.t() | {:error, any}
   def by_ids(ids, params \\ [], opts \\ [])
 
   def by_ids(ids, params, opts) when is_list(ids) do

--- a/lib/mbta_v3_api/trips.ex
+++ b/lib/mbta_v3_api/trips.ex
@@ -3,7 +3,8 @@ defmodule MBTAV3API.Trips do
   Responsible for fetching Trip data from the MBTA V3 API.
   """
 
-def by_ids(ids, params \\ [], opts \\ [])
+  def by_ids(ids, params \\ [], opts \\ [])
+
   def by_ids(ids, params, opts) when is_list(ids) do
     by_ids(Enum.join(ids, ","), params, opts)
   end

--- a/lib/mbta_v3_api/trips.ex
+++ b/lib/mbta_v3_api/trips.ex
@@ -3,6 +3,17 @@ defmodule MBTAV3API.Trips do
   Responsible for fetching Trip data from the MBTA V3 API.
   """
 
+def by_ids(ids, params \\ [], opts \\ [])
+  def by_ids(ids, params, opts) when is_list(ids) do
+    by_ids(Enum.join(ids, ","), params, opts)
+  end
+
+  def by_ids(ids, params, opts) do
+    params = Keyword.put(params, :"filter[id]", ids)
+    {get_json_fn, opts} = Keyword.pop(opts, :get_json_fn, &MBTAV3API.get_json/3)
+    get_json_fn.("/trips/", params, opts)
+  end
+
   def by_id(id, opts \\ []) do
     {get_json_fn, opts} = Keyword.pop(opts, :get_json_fn, &MBTAV3API.get_json/2)
     get_json_fn.("/trips/" <> id, opts)

--- a/test/mbta_v3_api/facilities/repo_test.exs
+++ b/test/mbta_v3_api/facilities/repo_test.exs
@@ -34,6 +34,14 @@ defmodule Facilities.RepoTest do
     ]
   }
 
+  describe "get_all/1" do
+    test "get parsed facilities from the api" do
+      with_mock Facilities, all: fn _params, _opts -> %JsonApi{data: [@item]} end do
+        assert [@expected_response] = Repo.all(include: "stop")
+      end
+    end
+  end
+
   describe "get_for_stop/1" do
     test "get facilities from the api" do
       response = %JsonApi{data: [%Item{}]}

--- a/test/mbta_v3_api/routes/repo_test.exs
+++ b/test/mbta_v3_api/routes/repo_test.exs
@@ -13,13 +13,13 @@ defmodule MBTAV3API.Routes.RepoTest do
 
   describe "all/0" do
     test "returns a list of Routes" do
-      with_mock(Routes, all: fn _opts -> %JsonApi{data: [@item]} end) do
+      with_mock(Routes, all: fn _params, _opts -> %JsonApi{data: [@item]} end) do
         assert [%Route{} | _] = Repo.all()
       end
     end
 
     test "parses the data into Route structs" do
-      with_mock(Routes, all: fn _opts -> %JsonApi{data: [@item]} end) do
+      with_mock(Routes, all: fn _params, _opts -> %JsonApi{data: [@item]} end) do
         assert Repo.all() |> List.first() == %Route{
                  id: "Orange",
                  type: 1,
@@ -69,7 +69,7 @@ defmodule MBTAV3API.Routes.RepoTest do
 
   describe "by_type/1" do
     test "only returns routes of a given type" do
-      with_mock(Routes, all: fn _opts -> %JsonApi{data: [@item]} end) do
+      with_mock(Routes, all: fn _params, _opts -> %JsonApi{data: [@item]} end) do
         one = Repo.by_type(1)
         assert one |> Enum.all?(fn route -> route.type == 1 end)
         assert one != []

--- a/test/mbta_v3_api/routes_test.exs
+++ b/test/mbta_v3_api/routes_test.exs
@@ -9,11 +9,10 @@ defmodule MBTAV3API.RoutesTest do
 
   describe "all/1" do
     test "gets all routes" do
+      params = @opts
       response = %JsonApi{data: [%Item{}]}
-
-      opts = Keyword.put(@opts, :get_json_fn, fn "/routes/", @opts -> response end)
-
-      assert Routes.all(opts) == response
+      opts = [get_json_fn: fn "/routes/", params, [] -> response end]
+      assert Routes.all(params, opts) == response
     end
   end
 

--- a/test/mbta_v3_api/stops/repo_test.exs
+++ b/test/mbta_v3_api/stops/repo_test.exs
@@ -144,7 +144,7 @@ defmodule MBTAV3API.Stops.RepoTest do
 
       opts = [
         by_route_type_fn: fn {^route_type, []} -> [child_stop_1, child_stop_2] end,
-        all_stops_fn: fn ["filter[id]": "stop-id"] -> [stop] end
+        all_stops_fn: fn ["filter[id]": "stop-id"], [] -> [stop] end
       ]
 
       response = Repo.by_route_type(route_type, opts)

--- a/test/mbta_v3_api/stops_test.exs
+++ b/test/mbta_v3_api/stops_test.exs
@@ -9,9 +9,9 @@ defmodule MBTAV3API.StopsTest do
     test "gets all stops" do
       response = %JsonApi{data: [%Item{}]}
 
-      opts = [get_json_fn: fn "/stops/", [] -> response end]
+      opts = [get_json_fn: fn "/stops/", [], [] -> response end]
 
-      assert Stops.all(opts) == response
+      assert Stops.all([], opts) == response
     end
   end
 

--- a/test/mbta_v3_api/trips_test.exs
+++ b/test/mbta_v3_api/trips_test.exs
@@ -5,11 +5,11 @@ defmodule MBTAV3API.TripsTest do
   alias JsonApi.Item
   alias MBTAV3API.Trips
 
-    describe "by_ids" do
+  describe "by_ids" do
     test "gets trips by their ids" do
       response = %JsonApi{data: [%Item{id: "123"}]}
 
-    opts = [get_json_fn: fn "/trips/", ["filter[id]": "123"], [] -> response end]
+      opts = [get_json_fn: fn "/trips/", ["filter[id]": "123"], [] -> response end]
 
       assert Trips.by_ids(["123"], [], opts) == response
     end

--- a/test/mbta_v3_api/trips_test.exs
+++ b/test/mbta_v3_api/trips_test.exs
@@ -5,6 +5,16 @@ defmodule MBTAV3API.TripsTest do
   alias JsonApi.Item
   alias MBTAV3API.Trips
 
+    describe "by_ids" do
+    test "gets trips by their ids" do
+      response = %JsonApi{data: [%Item{id: "123"}]}
+
+    opts = [get_json_fn: fn "/trips/", ["filter[id]": "123"], [] -> response end]
+
+      assert Trips.by_ids(["123"], [], opts) == response
+    end
+  end
+
   describe "by_id" do
     test "gets a trip by its ID" do
       response = %JsonApi{data: [%Item{id: "123"}]}


### PR DESCRIPTION
[ticket](https://app.asana.com/1/15492006741476/project/1204819229687089/task/1209048955001498?focus=true)

Ok, let me try to explain this one:

For the GTFS validator feature, I knew we'd need to use the API library to make API calls against different APIs. Fortunately, the functions that library uses to actually make the API calls takes in a keyword list called `opts` which with one can set the api url and api key. Unfortunately, the functions we call directly do not take this list in. They do take in an argument they call `opts`, but that is actually the `params`, eg filters and such to be passed as arguments to the API call itself. So I had to add a new argument to several of these calls. It was also missing a couple functions I wanted so I added those in. I attempted to follow the patterns of the codebase where applicable, but I also didn't refactor anything that I didn't directly touch. 

