### PR TITLE
Pass opts to FacilityRepo.get

### DIFF
--- a/lib/mbta_v3_api/facilities.ex
+++ b/lib/mbta_v3_api/facilities.ex
@@ -23,8 +23,8 @@ defmodule MBTAV3API.Facilities do
   end
 
   @spec get(String.t(), keyword()) :: api_response_t()
-  def get(id, opts \\ []) do
-    {get_json_fn, opts} = Keyword.pop(opts, :get_json_fn, &MBTAV3API.get_json/2)
-    get_json_fn.("/facilities/#{id}", opts)
+  def get(id, params \\ [], opts \\ []) do
+    {get_json_fn, opts} = Keyword.pop(opts, :get_json_fn, &MBTAV3API.get_json/3)
+    get_json_fn.("/facilities/#{id}", params, opts)
   end
 end

--- a/lib/mbta_v3_api/facilities/repo.ex
+++ b/lib/mbta_v3_api/facilities/repo.ex
@@ -19,9 +19,9 @@ defmodule MBTAV3API.Facilities.Repo do
     end
   end
 
-  def get(id, opts \\ []) when is_binary(id) do
-    case cache({id, opts}, fn {id, opts} ->
-           with %{data: [facility]} <- Facilities.get(id, opts) do
+  def get(id, params \\ [], opts \\ []) when is_binary(id) do
+    case cache({id, params, opts}, fn {id, params, opts} ->
+           with %{data: [facility]} <- Facilities.get(id, params, opts) do
              {:ok, facility}
            end
          end) do

--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -25,6 +25,7 @@ defmodule MBTAV3API.Stops.Repo do
   def all(params \\ [], opts \\ []) do
     cache({params, opts}, fn {params, opts} ->
       result = Api.all(params, opts)
+
       for stops <- [result], stop <- stops do
         ConCache.put(__MODULE__, {:get, stop.id}, {:ok, stop})
       end

--- a/test/mbta_v3_api/facilities/repo_test.exs
+++ b/test/mbta_v3_api/facilities/repo_test.exs
@@ -54,7 +54,7 @@ defmodule Facilities.RepoTest do
 
   describe "get/1" do
     test "get a parsed facility from the api" do
-      with_mock Facilities, get: fn _id, _opts -> %JsonApi{data: [@item]} end do
+      with_mock Facilities, get: fn _id, _params, _opts -> %JsonApi{data: [@item]} end do
         assert @expected_response = Repo.get("349", [])
       end
     end

--- a/test/mbta_v3_api/facilities_test.exs
+++ b/test/mbta_v3_api/facilities_test.exs
@@ -42,12 +42,12 @@ defmodule MBTAV3API.FacilitiesTest do
       response = %JsonApi{data: [%Item{id: "349"}]}
 
       opts = [
-        get_json_fn: fn "/facilities/349", [] ->
+        get_json_fn: fn "/facilities/349", [], [] ->
           response
         end
       ]
 
-      assert Facilities.get("349", opts) == response
+      assert Facilities.get("349", [], opts) == response
     end
   end
 end


### PR DESCRIPTION
[ticket](https://app.asana.com/1/15492006741476/project/1204819229687089/task/1209048955001498?focus=true)

It seems that you can't pass `id` as a filter to Facilities.all, so we are forced to make a bunch of Facilities.get calls during alert validation. So this function needs updated like the others so it can eventually take in a base url.