### PR TITLE
Add option to conditionally do route rejection

### DIFF
--- a/lib/mbta_v3_api/routes/repo.ex
+++ b/lib/mbta_v3_api/routes/repo.ex
@@ -33,6 +33,8 @@ defmodule MBTAV3API.Routes.Repo do
     combined_params = @default_params ++ params
 
     case cache({combined_params, opts}, fn {combined_params, opts} ->
+           # if reject_hidden keyword is true, reject routes
+           # listed in Route.hidden?. Defaults to true.
            reject_hidden = Keyword.get(opts, :reject_hidden, true)
            result = handle_response(Routes.all(combined_params, opts), reject_hidden)
 

--- a/lib/mbta_v3_api/routes/repo.ex
+++ b/lib/mbta_v3_api/routes/repo.ex
@@ -33,7 +33,8 @@ defmodule MBTAV3API.Routes.Repo do
     combined_params = @default_params ++ params
 
     case cache({combined_params, opts}, fn {combined_params, opts} ->
-           result = handle_response(Routes.all(combined_params, opts))
+           reject_hidden = Keyword.get(opts, :reject_hidden, true)
+           result = handle_response(Routes.all(combined_params, opts), reject_hidden)
 
            for {:ok, routes} <- [result],
                route <- routes do
@@ -187,16 +188,21 @@ defmodule MBTAV3API.Routes.Repo do
   @doc """
   Parses json into a list of routes, or an error if it happened.
   """
-  @spec handle_response(JsonApi.t() | {:error, any}) :: {:ok, [Route.t()]} | {:error, any}
-  def handle_response({:error, reason}) do
+  @spec handle_response(JsonApi.t() | {:error, any}, boolean()) ::
+          {:ok, [Route.t()]} | {:error, any}
+  def handle_response(data, reject_hidden? \\ true)
+
+  def handle_response({:error, reason}, _) do
     {:error, reason}
   end
 
-  def handle_response(%{data: data}) do
+  def handle_response(%{data: data}, reject_hidden?) do
     {:ok,
      data
      |> Enum.flat_map(&fetch_connecting_routes_via_stop/1)
-     |> Enum.reject(&Route.hidden?/1)
+     |> then(fn data ->
+       if reject_hidden?, do: Enum.reject(data, &Route.hidden?/1), else: data
+     end)
      |> Enum.map(&parse_route/1)
      |> Enum.uniq()
      |> Enum.sort_by(& &1.sort_order)}

--- a/test/mbta_v3_api/routes/repo_test.exs
+++ b/test/mbta_v3_api/routes/repo_test.exs
@@ -10,11 +10,29 @@ defmodule MBTAV3API.Routes.RepoTest do
   alias MBTAV3API.Shapes
 
   @item build(:route_data)
+  @rejectable_item %Item{
+    id: "441442",
+    attributes: %{
+      "direction_destinations" => ["Marblehead", "Wonderland Station"],
+      "direction_names" => ["Outbound", "Inbound"],
+      "long_name" => "evil combo route",
+      "type" => 3
+    }
+  }
 
   describe "all/0" do
     test "returns a list of Routes" do
-      with_mock(Routes, all: fn _params, _opts -> %JsonApi{data: [@item]} end) do
-        assert [%Route{} | _] = Repo.all()
+      with_mock(Routes, all: fn _params, _opts -> %JsonApi{data: [@item, @rejectable_item]} end) do
+        assert [%Route{} = route] = Repo.all()
+        assert route.id == @item.id
+      end
+    end
+
+    test "includes rejectable routes if reject_hidden is false" do
+      with_mock(Routes, all: fn _params, _opts -> %JsonApi{data: [@item, @rejectable_item]} end) do
+        assert [%Route{} = route1, %Route{} = route2] = Repo.all([], reject_hidden: false)
+        assert route1.id == @item.id
+        assert route2.id == @rejectable_item.id
       end
     end
 


### PR DESCRIPTION
[ticket](https://app.asana.com/1/15492006741476/project/1204819229687089/task/1209048955001498?focus=true)

We were tossing out some routes (mostly combo routes) whose IDs appeared on a hardcoded list. I don't want to deal with the wide-ranging fallout of tossing out the list right now, so I'm disabling it based on passed-in options. If the option is not passed, the behavior is unchanged.