### PR TITLE
Return "listed route" attribute for routes in route patterns

### DIFF
--- a/lib/mbta_v3_api/route_patterns/route_pattern.ex
+++ b/lib/mbta_v3_api/route_patterns/route_pattern.ex
@@ -36,6 +36,7 @@ defmodule MBTAV3API.RoutePatterns.RoutePattern do
     :stop_ids,
     :stops,
     :route_id,
+    :listed_route,
     :time_desc,
     :typicality,
     :service_id,
@@ -56,6 +57,7 @@ defmodule MBTAV3API.RoutePatterns.RoutePattern do
           stop_ids: [Stop.id_t()],
           stops: [Stop.t()],
           route_id: Route.id_t(),
+          listed_route: boolean() | nil,
           time_desc: String.t(),
           typicality: typicality_t(),
           sort_order: integer(),
@@ -81,7 +83,9 @@ defmodule MBTAV3API.RoutePatterns.RoutePattern do
               relationships: trip_relationships
             }
           ],
-          "route" => [%Item{id: route_id}]
+          "route" => [
+            %Item{id: route_id, attributes: route_attributes}
+          ]
         }
       }) do
     %__MODULE__{
@@ -95,6 +99,7 @@ defmodule MBTAV3API.RoutePatterns.RoutePattern do
       stop_ids: stop_ids(trip_relationships),
       stops: stops(trip_relationships),
       route_id: route_id,
+      listed_route: Map.get(route_attributes, "listed_route"),
       time_desc: time_desc,
       typicality: typicality,
       sort_order: sort_order,
@@ -113,7 +118,9 @@ defmodule MBTAV3API.RoutePatterns.RoutePattern do
         },
         relationships: %{
           "representative_trip" => [%Item{id: representative_trip_id}],
-          "route" => [%Item{id: route_id}]
+          "route" => [
+            %Item{id: route_id, attributes: route_attributes}
+          ]
         }
       }) do
     %__MODULE__{
@@ -122,6 +129,7 @@ defmodule MBTAV3API.RoutePatterns.RoutePattern do
       name: name,
       representative_trip_id: representative_trip_id,
       route_id: route_id,
+      listed_route: Map.get(route_attributes, "listed_route"),
       time_desc: time_desc,
       typicality: typicality,
       sort_order: sort_order

--- a/test/mbta_v3_api/route_patterns/route_pattern_test.exs
+++ b/test/mbta_v3_api/route_patterns/route_pattern_test.exs
@@ -17,6 +17,7 @@ defmodule MBTAV3API.RoutePatterns.RoutePatternTest do
         name: "Haymarket Station - Woodlawn",
         representative_trip_id: "60311384",
         route_id: "111",
+        listed_route: true,
         typicality: 1,
         sort_order: 511_100_000
       }
@@ -34,6 +35,7 @@ defmodule MBTAV3API.RoutePatterns.RoutePatternTest do
                headsign: "Braintree",
                representative_trip_id: "canonical-Red-C1-0",
                route_id: "Red",
+               listed_route: true,
                service_id: "canonical",
                shape_id: "canonical-933_0009",
                sort_order: 100_100_000,

--- a/test/mbta_v3_api/routes/parser_test.exs
+++ b/test/mbta_v3_api/routes/parser_test.exs
@@ -145,7 +145,7 @@ defmodule MBTAV3API.Routes.ParserTest do
               },
               relationships: %{
                 "representative_trip" => [%Item{id: "id"}],
-                "route" => [%Item{id: "id"}]
+                "route" => [%Item{id: "id", attributes: %{}}]
               }
             }
           ]

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -445,7 +445,8 @@ defmodule MBTAV3API.Support.Factory do
         "route" => [
           %Item{
             id: "111",
-            type: "route"
+            type: "route",
+            attributes: %{"listed_route" => true}
           }
         ]
       }
@@ -476,10 +477,10 @@ defmodule MBTAV3API.Support.Factory do
             relationships: %{
               "route" => [
                 %Item{
-                  attributes: nil,
                   id: "Red",
                   relationships: nil,
-                  type: "route"
+                  type: "route",
+                  attributes: %{}
                 }
               ],
               "route_pattern" => [
@@ -548,7 +549,7 @@ defmodule MBTAV3API.Support.Factory do
         ],
         "route" => [
           %Item{
-            attributes: nil,
+            attributes: %{"listed_route" => true},
             id: "Red",
             relationships: nil,
             type: "route"
@@ -697,7 +698,7 @@ defmodule MBTAV3API.Support.Factory do
                     %JsonApi.Item{
                       type: "route",
                       id: "Red",
-                      attributes: nil,
+                      attributes: %{},
                       relationships: nil
                     }
                   ],
@@ -1425,7 +1426,7 @@ defmodule MBTAV3API.Support.Factory do
               %JsonApi.Item{
                 type: "route",
                 id: "Red",
-                attributes: nil,
+                attributes: %{"listed_route" => true},
                 relationships: nil
               }
             ]
@@ -1461,7 +1462,7 @@ defmodule MBTAV3API.Support.Factory do
                     %JsonApi.Item{
                       type: "route",
                       id: "Red",
-                      attributes: nil,
+                      attributes: %{},
                       relationships: nil
                     }
                   ],
@@ -2151,7 +2152,7 @@ defmodule MBTAV3API.Support.Factory do
               %JsonApi.Item{
                 type: "route",
                 id: "Red",
-                attributes: nil,
+                attributes: %{"listed_route" => true},
                 relationships: nil
               }
             ]
@@ -2187,7 +2188,7 @@ defmodule MBTAV3API.Support.Factory do
                     %JsonApi.Item{
                       type: "route",
                       id: "Red",
-                      attributes: nil,
+                      attributes: %{},
                       relationships: nil
                     }
                   ],
@@ -2421,7 +2422,7 @@ defmodule MBTAV3API.Support.Factory do
               %JsonApi.Item{
                 type: "route",
                 id: "Red",
-                attributes: nil,
+                attributes: %{"listed_route" => true},
                 relationships: nil
               }
             ]


### PR DESCRIPTION
ticket: https://app.asana.com/1/15492006741476/task/1212327019459659

the "listed route" attribute, while a little confusingly named, tells us if a route returned with a route pattern should be used as a "combo route" (it should be used as one if this value is "false". It's usually "true"). This change just gets that field returned with the route pattern so we can use it up in our app.