### PR TITLE
Pass params in through Route.by_type

### DIFF
--- a/lib/mbta_v3_api/lines/repo.ex
+++ b/lib/mbta_v3_api/lines/repo.ex
@@ -5,6 +5,7 @@ defmodule MBTAV3API.Lines.Repo do
   use RepoCache, ttl: :timer.hours(1)
   alias JsonApi
   alias MBTAV3API.Lines
+  alias MBTAV3API.Lines.Line
   alias MBTAV3API.Lines.Parser
 
   @default_opts [include: "routes"]

--- a/lib/mbta_v3_api/routes/repo.ex
+++ b/lib/mbta_v3_api/routes/repo.ex
@@ -130,22 +130,24 @@ defmodule MBTAV3API.Routes.Repo do
   end
 
   @impl RepoApi
-  def by_type(types) when is_list(types) do
+  def by_type(types, params \\ [])
+
+  def by_type(types, params) when is_list(types) do
     types = Enum.sort(types)
 
-    case cache(types, &by_type_uncached/1) do
+    case cache({types, params}, &by_type_uncached/1) do
       {:ok, routes} -> routes
       {:error, _} -> []
     end
   end
 
-  def by_type(type) do
-    by_type([type])
+  def by_type(type, params) do
+    by_type([type], params)
   end
 
-  @spec by_type_uncached([0..4]) :: {:ok, [Route.t()]} | {:error, any}
-  defp by_type_uncached(types) do
-    case all() do
+  @spec by_type_uncached({[0..4], list()}) :: {:ok, [Route.t()]} | {:error, any}
+  defp by_type_uncached({types, params}) do
+    case all(params) do
       [] -> {:error, "no routes"}
       routes -> {:ok, Enum.filter(routes, fn route -> route.type in types end)}
     end


### PR DESCRIPTION
[ticket](https://app.asana.com/1/15492006741476/project/1204819229687089/task/1211293073772739?focus=true)

Passes any given params through the Routes.by_type function through to the function beneath, so they actually get into the API call. Necessary to eventually get unlisted routes in the form.

Also did a tiny fix to an unrelated file to satisfy the Dialyzer.