### PR TITLE
Cache stops_by_route with options only

### DIFF
--- a/lib/mbta_v3_api/stops/repo.ex
+++ b/lib/mbta_v3_api/stops/repo.ex
@@ -94,16 +94,7 @@ defmodule MBTAV3API.Stops.Repo do
   def by_route(route_id, direction_id, opts \\ []) do
     {by_route_fn, opts} = Keyword.pop(opts, :by_route_fn, &Api.by_route/1)
 
-    cache({route_id, direction_id, opts}, fn args ->
-      with stops when is_list(stops) <- by_route_fn.(args) do
-        for stop <- stops do
-          # Put the stop in the cache under {:stop, id} key as well so it will
-          # also be cached for Stops.Repo.get/1 calls
-          ConCache.put(__MODULE__, {:stop, stop.id}, {:ok, stop})
-          stop
-        end
-      end
-    end)
+    cache({route_id, direction_id, opts}, by_route_fn)
   end
 
   @spec by_route_type(Route.type_int()) :: stops_response()

--- a/test/mbta_v3_api/stops/repo_test.exs
+++ b/test/mbta_v3_api/stops/repo_test.exs
@@ -110,26 +110,6 @@ defmodule MBTAV3API.Stops.RepoTest do
 
       assert Repo.by_route(route_id, direction_id, opts) == response
     end
-
-    test "caches per-stop as well" do
-      route_id = "Red"
-      direction_id = 1
-      stop_id = "place-brntn"
-
-      get_opts = [stops_by_gtfs_id_fn: fn ^stop_id -> {:ok, %Stop{id: stop_id}} end]
-
-      ConCache.delete(Repo, {:by_route, {route_id, direction_id, []}})
-      ConCache.put(Repo, {:stop, stop_id}, {:ok, "to-be-overwritten"})
-      assert Repo.get(stop_id, get_opts) == "to-be-overwritten"
-
-      by_route_opts = [
-        by_route_fn: fn {^route_id, ^direction_id, []} -> [%Stop{id: stop_id}] end
-      ]
-
-      Repo.by_route(route_id, direction_id, by_route_opts)
-
-      assert %Stop{id: ^stop_id} = Repo.get("place-brntn", get_opts)
-    end
   end
 
   describe "by_route_type/2" do


### PR DESCRIPTION
[asana ticket](https://app.asana.com/1/15492006741476/project/1167196461144361/task/1213725834649804?focus=true)


We were using 2 of these Stop functions: `by_route`, which we wanted with child stops, and `get`, which we want with child stops. `by_route` can take in options, `get` can't. And that's fine because the default for `get` is to have child stops and that's fine. Since `get` can't take in options, its cache key only has the stop id. `by_route`'s cache key DOES have the options in it, but it ALSO, in an attempt to be helpful, cached with just the stop id, so that calls to `get` could use its cache entries. HOWEVER, this means that if we include an option to `by_route` to ask for no child stops, that gets cached, without options, so next time we call `get`, we get that child stopless response out of the cache.

There were a couple ways to fix this (eg we could have made calls to `get` take in options and then use them in the cache key) but this seemed like the simplest. This does mean calls to `get` will hit the cache less often. We call this function in 3 places: 1. when creating a facility alert 2. when grabbing data to edit an alert which does not have original stop selections 3. when building a Trapeze alert.