### PR TITLE
Pass `added_routes` through schedules repo

### DIFF
--- a/lib/mbta_v3_api/schedules/parser.ex
+++ b/lib/mbta_v3_api/schedules/parser.ex
@@ -22,7 +22,8 @@ defmodule MBTAV3API.Schedules.Parser do
           early_departure? :: boolean,
           last_stop? :: boolean,
           stop_sequence :: integer,
-          pickup_type :: integer
+          pickup_type :: integer,
+          added_route_ids :: [Route.id_t()]
         }
 
   @spec parse(Item.t()) :: record
@@ -42,12 +43,17 @@ defmodule MBTAV3API.Schedules.Parser do
       early_departure?(item),
       last_stop?(item),
       item.attributes["stop_sequence"] || 0,
-      pickup_type(item)
+      pickup_type(item),
+      added_route_ids(item)
     }
   end
 
   def route_id(%Item{relationships: %{"route" => [%Item{id: id} | _]}}) do
     id
+  end
+
+  def added_route_ids(%Item{relationships: %{"added_routes" => routes}}) do
+    Enum.map(routes, fn route -> route.id end)
   end
 
   def trip_id(%Item{relationships: %{"trip" => [%Item{id: id} | _]}}) do

--- a/lib/mbta_v3_api/schedules/repo.ex
+++ b/lib/mbta_v3_api/schedules/repo.ex
@@ -167,19 +167,19 @@ defmodule MBTAV3API.Schedules.Repo do
     end
   end
 
-  def has_trip?({_, trip_id, _, _, _, _, _, _, _, _, _}) when is_nil(trip_id) do
+  def has_trip?({_, trip_id, _, _, _, _, _, _, _, _, _, _}) when is_nil(trip_id) do
     false
   end
 
-  def has_trip?({_, _, _, _, _, _, _, _, _, _, _}) do
+  def has_trip?({_, _, _, _, _, _, _, _, _, _, _, _}) do
     true
   end
 
-  defp date_sorter({_, _, _, _, _, %DateTime{} = time, _, _, _, _, _}) do
+  defp date_sorter({_, _, _, _, _, %DateTime{} = time, _, _, _, _, _, _}) do
     DateTime.to_unix(time)
   end
 
-  defp date_sorter({_, _, _, _, _, _, _, _, _, _, _}) do
+  defp date_sorter({_, _, _, _, _, _, _, _, _, _, _, _}) do
     0
   end
 
@@ -261,7 +261,7 @@ defmodule MBTAV3API.Schedules.Repo do
   defp load_from_other_repos(schedules) do
     schedules
     |> Enum.map(fn {route_id, trip_id, stop_id, arrival_time, departure_time, time, flag?,
-                    early_departure?, last_stop?, stop_sequence, pickup_type} ->
+                    early_departure?, last_stop?, stop_sequence, pickup_type, added_route_ids} ->
       Task.async(fn ->
         %Schedule{
           route: RoutesRepo.get(route_id),
@@ -275,7 +275,8 @@ defmodule MBTAV3API.Schedules.Repo do
           early_departure?: early_departure?,
           last_stop?: last_stop?,
           stop_sequence: stop_sequence,
-          pickup_type: pickup_type
+          pickup_type: pickup_type,
+          added_route_ids: added_route_ids
         }
       end)
     end)

--- a/lib/mbta_v3_api/schedules/schedule.ex
+++ b/lib/mbta_v3_api/schedules/schedule.ex
@@ -20,7 +20,8 @@ defmodule MBTAV3API.Schedules.Schedule do
             last_stop?: false,
             stop_sequence: 0,
             pickup_type: 0,
-            platform_stop_id: nil
+            platform_stop_id: nil,
+            added_route_ids: []
 
   @typedoc "If the scheduled stop has a parent stop (station), then the `stop` field will contain that parent stop. Otherwise it will contain the scheduled platform stop. Whether or not the stop has a parent, the unmodified stop id can be found in platform_stop_id field."
   @type stop :: Stop.t()
@@ -37,7 +38,8 @@ defmodule MBTAV3API.Schedules.Schedule do
           last_stop?: boolean,
           stop_sequence: non_neg_integer,
           pickup_type: integer,
-          platform_stop_id: Stop.id_t()
+          platform_stop_id: Stop.id_t(),
+          added_route_ids: [Route.id_t()]
         }
 
   def flag?(%__MODULE__{flag?: value}), do: value

--- a/test/mbta_v3_api/schedules/parser_test.exs
+++ b/test/mbta_v3_api/schedules/parser_test.exs
@@ -23,7 +23,27 @@ defmodule MBTAV3API.Schedules.ParserTest do
         assert {"CR-Lowell", "31174458-CR_MAY2016-hxl16011-Weekday-01", "Lowell", nil,
                 Timex.to_datetime({{2016, 6, 8}, {5, 35, 0}}, "Etc/UTC-4"),
                 Timex.to_datetime({{2016, 6, 8}, {5, 35, 0}}, "Etc/UTC-4"), true, true, false, 0,
-                3} == actual
+                3, []} == actual
+      end
+    end
+
+    test "parse converts a JsonApi.Item into a tuple including added routes" do
+      with_mock(RoutesRepo, get: fn _ -> %Route{type: 2} end) do
+        api_item = build(:schedule_data)
+
+        relationships =
+          Map.merge(api_item.relationships, %{
+            "added_routes" => [%JsonApi.Item{id: "Boat-F1", type: "route"}]
+          })
+
+        api_item = %{api_item | relationships: relationships}
+
+        actual = Parser.parse(api_item)
+
+        assert {"CR-Lowell", "31174458-CR_MAY2016-hxl16011-Weekday-01", "Lowell", nil,
+                Timex.to_datetime({{2016, 6, 8}, {5, 35, 0}}, "Etc/UTC-4"),
+                Timex.to_datetime({{2016, 6, 8}, {5, 35, 0}}, "Etc/UTC-4"), true, true, false, 0,
+                3, ["Boat-F1"]} == actual
       end
     end
   end

--- a/test/mbta_v3_api/schedules/repo_test.exs
+++ b/test/mbta_v3_api/schedules/repo_test.exs
@@ -279,7 +279,7 @@ defmodule MBTAV3API.Schedules.RepoTest do
       assert Repo.has_trip?(
                {"CR-Lowell", "CR-Weekday-Fall-18-348", "place-NHRML-0254", nil,
                 "2018-11-05 23:05:00-05:00 -05 Etc/GMT+5",
-                "2018-11-05 23:05:00-05:00 -05 Etc/GMT+5", false, false, false, 1, 0}
+                "2018-11-05 23:05:00-05:00 -05 Etc/GMT+5", false, false, false, 1, 0, []}
              )
     end
 
@@ -287,7 +287,7 @@ defmodule MBTAV3API.Schedules.RepoTest do
       refute Repo.has_trip?(
                {"CR-Lowell", nil, "place-NHRML-0254", nil,
                 "2018-11-05 23:05:00-05:00 -05 Etc/GMT+5",
-                "2018-11-05 23:05:00-05:00 -05 Etc/GMT+5", false, false, false, 1, 0}
+                "2018-11-05 23:05:00-05:00 -05 Etc/GMT+5", false, false, false, 1, 0, []}
              )
     end
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -570,6 +570,7 @@ defmodule MBTAV3API.Support.Factory do
         "timepoint" => false
       },
       relationships: %{
+        "added_routes" => [],
         "stop" => [
           %Item{
             attributes: %{


### PR DESCRIPTION
The API is already returning `added_routes` by default (see https://api-v3.mbta.com/schedules?filter%5Btrip%5D=Boat-F1-1000-Rowes-F1-B-Weekday-Summer-26). This makes the parser in the SchedulesRepo expect `added_routes` and pull out their IDs to pass on. We need this for [☄️ Create additional informed entities for multi-route trips](https://app.asana.com/1/15492006741476/project/1167196461144361/task/1214283628700415?focus=true)

Tests aren't consistently passing, but from what I can tell they are the same tests that aren't passing on the base branch