### PR TITLE
Have schedule include just route_id instead of entire route

### DIFF
--- a/lib/mbta_v3_api/schedules/repo.ex
+++ b/lib/mbta_v3_api/schedules/repo.ex
@@ -3,7 +3,6 @@ defmodule MBTAV3API.Schedules.Repo do
   import Kernel, except: [to_string: 1]
   use RepoCache, ttl: :timer.hours(1)
 
-  alias MBTAV3API.Routes.Repo, as: RoutesRepo
   alias MBTAV3API.Routes.Route
   alias MBTAV3API.Schedules
   alias MBTAV3API.Schedules.{HoursOfOperation, Parser, Schedule, Trip}
@@ -264,7 +263,7 @@ defmodule MBTAV3API.Schedules.Repo do
                     early_departure?, last_stop?, stop_sequence, pickup_type, added_route_ids} ->
       Task.async(fn ->
         %Schedule{
-          route: RoutesRepo.get(route_id),
+          route_id: route_id,
           trip: trip(trip_id),
           platform_stop_id: stop_id,
           stop: StopsRepo.get_parent(stop_id),

--- a/lib/mbta_v3_api/schedules/schedule.ex
+++ b/lib/mbta_v3_api/schedules/schedule.ex
@@ -9,7 +9,7 @@ defmodule MBTAV3API.Schedules.Schedule do
 
   @derive Jason.Encoder
 
-  defstruct route: nil,
+  defstruct route_id: nil,
             trip: nil,
             stop: nil,
             arrival_time: nil,
@@ -24,12 +24,11 @@ defmodule MBTAV3API.Schedules.Schedule do
             added_route_ids: []
 
   @typedoc "If the scheduled stop has a parent stop (station), then the `stop` field will contain that parent stop. Otherwise it will contain the scheduled platform stop. Whether or not the stop has a parent, the unmodified stop id can be found in platform_stop_id field."
-  @type stop :: Stop.t()
 
   @type t :: %__MODULE__{
-          route: Route.t(),
+          route_id: Route.id_t(),
           trip: Trip.t(),
-          stop: stop,
+          stop: Stop.t(),
           arrival_time: DateTime.t() | nil,
           departure_time: DateTime.t() | nil,
           time: DateTime.t(),


### PR DESCRIPTION
Right now every api call to get a schedule makes 2 more api calls, 1 for route and 1 for stop. We don't reallly need the route one, I was able to make a few small changes to the alerts_manager code and remove the need for it. So this change makes it so the schedule struct just had a route_id and not an entire route.
It seems small, but there are some cases where editing an alert in alerts manager will make hundreds of calls for schedules. I don't think getting rid of this will speed things up right away, but I'm hoping I can then take another stab at doing cache warming for schedules without running into API rate limits. (but I think it also does speed things up at least a little bit.)